### PR TITLE
Allows loop to detect instances of KSampler (Advanced)

### DIFF
--- a/scripts/iib/tool.py
+++ b/scripts/iib/tool.py
@@ -308,7 +308,7 @@ def get_comfyui_exif_data(img: Image):
     for i in range(3, 32):
         try:
             i = str(i)
-            if data[i]["class_type"] == "KSampler":
+            if data[i]["class_type"].startswith("KSampler"):
                 meta_key = i
                 break
         except:


### PR DESCRIPTION
Instead of checking for an exact match, KSampler and KSampler (Advanced) start with the same characters so the str.startswith method would be an efficient way to check for both.